### PR TITLE
  Repair CI (Temporary solution)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools>=45",
+    "setuptools<64",
     "setuptools_scm>=6.4",
     "wheel>=0.37",
     "ninja>=1.10; sys_platform != 'win32'",


### PR DESCRIPTION
CI is currently failing due to https://github.com/pypa/setuptools/pull/3488 implementing PEP660 editable installs in setuptools (starting with version 64)

As a temporary solution the setuptools version is forced to be less than 64