### PR TITLE
🐛 Fix Editable Installs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools<64",
+    "setuptools>=45",
     "setuptools_scm>=6.4",
     "wheel>=0.37",
     "ninja>=1.10; sys_platform != 'win32'",


### PR DESCRIPTION
This PR fixes the Python packaging configuration so that editable installs work again and the latest version of setuptools can be used.

Fixes #63.