### PR TITLE
🔧 Add in-progress cancellation to CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
     branches: [main, master]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   BUILD_TYPE: Release
   MAKEFLAGS: "-j2"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,6 +8,10 @@ on:
   schedule:
     - cron: "15 21 * * 6"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,10 @@ on:
     branches: [main, master]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   BOOST_HASH: 3a336c8b1a917f7d9c55abba2905be99dade914bf9b829aab9d5fb6069b6ffcc
   BOOST_VERSION_MAJOR: 1


### PR DESCRIPTION
Per default, GitHub keeps workflows running even if new commits are added to a pull request.
This is wasteful and requires lots of manual cancellations to free up available runners.
This PR adds the corresponding settings to cancel in-progress jobs whenever new commits become available by adding
```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```
snippets to all the workflow files.