### PR TITLE
📦 Support Versioning in Git Archives

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,4 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$
+ref-names: $Format:%D$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+test/circuits/** linguist-vendored
+.git_archival.txt  export-subst

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "setuptools>=45",
-    "setuptools_scm>=6.4",
+    "setuptools_scm>=7",
     "ninja>=1.10; sys_platform != 'win32'",
     "cmake>=3.14",
 ]


### PR DESCRIPTION
## Description

Following https://scikit-hep.org/developer/packaging#versioning-mediumhigh-priority, this PR adds the necessary steps to allow git archives (including the ones generated from GitHub) to also support versioning.
This requires setuptools_scm>=7.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
