### PR TITLE
Add export to OpenQASM 2.0 for simple circuits

### DIFF
--- a/include/core/circuit.hpp
+++ b/include/core/circuit.hpp
@@ -428,6 +428,12 @@ namespace syrec {
             return cost;
         }
 
+        // To QASM
+        /**
+         * @brief Convert circuit to QASM string. Only supports X, CX, CCX, CCCX, SWAP, c-SWAP gates.
+         * @return QASM string
+         */
+
         [[nodiscard]] std::string toQasm() const {
             std::stringstream ss;
             ss << "OPENQASM 2.0;\n";
@@ -441,7 +447,11 @@ namespace syrec {
             return ss.str();
         }
 
-        // write directly to file given the path
+        /**
+         * @brief Write circuit to QASM file. Only supports X, CX, CCX, CCCX, SWAP, c-SWAP gates.
+         * @param filename Filename
+         * @return True if successful
+         */
         [[nodiscard]] bool toQasmFile(const std::string& filename) const {
             std::ofstream of;
             of.open(filename.c_str());

--- a/include/core/circuit.hpp
+++ b/include/core/circuit.hpp
@@ -428,19 +428,13 @@ namespace syrec {
             return cost;
         }
 
-        // To QASM
         /**
-         * @brief Convert circuit to QASM string. Only supports X, CX, CCX, CCCX, SWAP, c-SWAP gates.
+         * @brief Convert circuit to QASM string.
          * @return QASM string
          */
-
         [[nodiscard]] std::string toQasm() const {
             std::stringstream ss;
-            ss << "OPENQASM 2.0;\n";
-            ss << "include \"qelib1.inc\";\n";
-            ss << "gate mcx q0,q1,q2,q3 { h q3; p(pi/8) q0; p(pi/8) q1; p(pi/8) q2; p(pi/8) q3; cx q0,q1; p(-pi/8) q1; cx q0,q1; cx q1,q2; p(-pi/8) q2; cx q0,q2; p(pi/8) q2; cx q1,q2; p(-pi/8) q2; cx q0,q2; cx q2,q3; p(-pi/8) q3; cx q1,q3; p(pi/8) q3; cx q2,q3; p(-pi/8) q3; cx q0,q3; p(pi/8) q3; cx q2,q3; p(-pi/8) q3; cx q1,q3; p(pi/8) q3; cx q2,q3; p(-pi/8) q3; cx q0,q3; h q3; } ";
-            ss << "qreg q[" << lines << "];\n";
-            ss << "creg c[" << lines << "];\n";
+            ss << "OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[" << lines << "];\n";
             for (const auto& g: gates) {
                 ss << g->toQasm() << "\n";
             }
@@ -448,19 +442,18 @@ namespace syrec {
         }
 
         /**
-         * @brief Write circuit to QASM file. Only supports X, CX, CCX, CCCX, SWAP, c-SWAP gates.
-         * @param filename Filename
-         * @return True if successful
+         * @brief Write circuit to QASM file.
+         * @param filename Filename (should end with .qasm)
+         * @return True if successful, false otherwise
          */
         [[nodiscard]] bool toQasmFile(const std::string& filename) const {
-            std::ofstream of;
-            of.open(filename.c_str());
-            if (of.is_open()) {
-                of << toQasm();
-                of.close();
-                return true;
+            std::ofstream file(filename);
+            if (!file.is_open()) {
+                return false;
             }
-            return false;
+            file << toQasm();
+            file.close();
+            return true;
         }
 
     private:

--- a/include/core/circuit.hpp
+++ b/include/core/circuit.hpp
@@ -449,7 +449,7 @@ namespace syrec {
         [[nodiscard]] bool toQasmFile(const std::string& filename) const {
             std::ofstream file(filename);
             if (!file.is_open()) {
-                return false;
+                return false; // GCOVR_EXCL_LINE
             }
             file << toQasm();
             file.close();

--- a/include/core/circuit.hpp
+++ b/include/core/circuit.hpp
@@ -3,6 +3,7 @@
 #include "gate.hpp"
 
 #include <boost/signals2.hpp>
+#include <fstream>
 #include <map>
 #include <memory>
 #include <optional>
@@ -425,6 +426,31 @@ namespace syrec {
                 cost += (8ULL * g->controls.size());
             }
             return cost;
+        }
+
+        [[nodiscard]] std::string toQasm() const {
+            std::stringstream ss;
+            ss << "OPENQASM 2.0;\n";
+            ss << "include \"qelib1.inc\";\n";
+            ss << "gate mcx q0,q1,q2,q3 { h q3; p(pi/8) q0; p(pi/8) q1; p(pi/8) q2; p(pi/8) q3; cx q0,q1; p(-pi/8) q1; cx q0,q1; cx q1,q2; p(-pi/8) q2; cx q0,q2; p(pi/8) q2; cx q1,q2; p(-pi/8) q2; cx q0,q2; cx q2,q3; p(-pi/8) q3; cx q1,q3; p(pi/8) q3; cx q2,q3; p(-pi/8) q3; cx q0,q3; p(pi/8) q3; cx q2,q3; p(-pi/8) q3; cx q1,q3; p(pi/8) q3; cx q2,q3; p(-pi/8) q3; cx q0,q3; h q3; } ";
+            ss << "qreg q[" << lines << "];\n";
+            ss << "creg c[" << lines << "];\n";
+            for (const auto& g: gates) {
+                ss << g->toQasm() << "\n";
+            }
+            return ss.str();
+        }
+
+        // write directly to file given the path
+        [[nodiscard]] bool toQasmFile(const std::string& filename) const {
+            std::ofstream of;
+            of.open(filename.c_str());
+            if (of.is_open()) {
+                of << toQasm();
+                of.close();
+                return true;
+            }
+            return false;
         }
 
     private:

--- a/include/core/gate.hpp
+++ b/include/core/gate.hpp
@@ -106,6 +106,10 @@ namespace syrec {
             return costs;
         }
 
+        /**
+         * @brief Returns the QASM string representation of the gate. Only supports X, CX, CCX, and SWAP gates.
+         * @return
+         */
         [[nodiscard]] std::string toQasm() const {
             std::stringstream ss;
             if (type == Types::Fredkin) {

--- a/include/core/gate.hpp
+++ b/include/core/gate.hpp
@@ -132,15 +132,15 @@ namespace syrec {
                     throw std::runtime_error("Gate not supported");
             }
             for (const auto& control: controls) {
-                ss << " q[" << control << "], ";
+                ss << " q[" << control << "],";
             }
             if (type == Types::Toffoli) {
                 assert(targets.size() == 1U);
-                ss << "q[" << *targets.begin() << "];";
+                ss << " q[" << *targets.begin() << "];";
             } else {
                 assert(type == Types::Fredkin);
                 assert(targets.size() == 2U);
-                ss << "q[" << *targets.begin() << "], q[" << *std::next(targets.begin()) << "];";
+                ss << " q[" << *targets.begin() << "], q[" << *std::next(targets.begin()) << "];";
             }
             return ss.str();
         }

--- a/include/core/gate.hpp
+++ b/include/core/gate.hpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <any>
+#include <cassert>
 #include <iostream>
 #include <set>
 #include <sstream>

--- a/include/core/gate.hpp
+++ b/include/core/gate.hpp
@@ -4,6 +4,7 @@
 #include <any>
 #include <iostream>
 #include <set>
+#include <sstream>
 #include <vector>
 
 namespace syrec {
@@ -103,6 +104,41 @@ namespace syrec {
             }
 
             return costs;
+        }
+
+        [[nodiscard]] std::string toQasm() const {
+            std::stringstream ss;
+            if (type == Types::Fredkin) {
+                switch (controls.size()) {
+                    case 0:
+                        ss << "swap q[" << *targets.begin() << "], q[" << *std::next(targets.begin()) << "];";
+                        break;
+                    case 1:
+                        ss << "cswap q[" << *controls.begin() << "], q[" << *targets.begin() << "], q[" << *std::next(targets.begin()) << "];";
+                }
+            } else if (type == Types::Toffoli && controls.size() <= 3) {
+                switch (controls.size()) {
+                    case 0:
+                        ss << "x q[" << *targets.begin() << "];";
+                        break;
+                    case 1:
+                        ss << "cx q[" << *controls.begin() << "], q[" << *targets.begin() << "];";
+                        break;
+                    case 2:
+                        ss << "ccx q[" << *controls.begin() << "], q[" << *std::next(controls.begin()) << "], q[" << *targets.begin() << "];";
+                        break;
+                    case 3:
+                        ss << "mcx q[" << *controls.begin() << "], q["
+                           << *std::next(controls.begin()) << "], q["
+                           << *std::next(std::next(controls.begin())) << "], q["
+                           << *targets.begin() << "];";
+                        break;
+                }
+            } else {
+                // throw gate not supported error
+                throw std::runtime_error("Gate not supported");
+            }
+            return ss.str();
         }
 
         line_container controls{};

--- a/include/core/gate.hpp
+++ b/include/core/gate.hpp
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <any>
-#include <cassert>
 #include <iostream>
 #include <set>
 #include <sstream>
@@ -137,11 +136,8 @@ namespace syrec {
                 ss << " q[" << control << "],";
             }
             if (type == Types::Toffoli) {
-                assert(targets.size() == 1U);
                 ss << " q[" << *targets.begin() << "];";
             } else {
-                assert(type == Types::Fredkin);
-                assert(targets.size() == 2U);
                 ss << " q[" << *targets.begin() << "], q[" << *std::next(targets.begin()) << "];";
             }
             return ss.str();

--- a/include/core/gate.hpp
+++ b/include/core/gate.hpp
@@ -47,7 +47,7 @@ namespace syrec {
                 c += 1U;
             }
 
-            c += std::max(-1 * static_cast<int>(c), 0);
+            c += static_cast<std::size_t>(std::max(-1 * static_cast<int>(c), 0));
             c = std::min(static_cast<unsigned>(c), lines - 1U);
 
             unsigned e = n - static_cast<unsigned>(c) - 1U; // empty lines

--- a/include/core/gate.hpp
+++ b/include/core/gate.hpp
@@ -128,9 +128,10 @@ namespace syrec {
                 case Types::Toffoli:
                     ss << "x";
                     break;
+                // GCOVR_EXCL_START
                 default:
-                    // throw gate not supported error
                     throw std::runtime_error("Gate not supported");
+                    // GCOVR_EXCL_STOP
             }
             for (const auto& control: controls) {
                 ss << " q[" << control << "],";

--- a/mqt/syrec/bindings.cpp
+++ b/mqt/syrec/bindings.cpp
@@ -43,7 +43,9 @@ PYBIND11_MODULE(pysyrec, m) {
                     },
                     "This method returns all annotations for a given gate.")
             .def("quantum_cost", &syrec::Circuit::quantumCost, "Returns the quantum cost of the circuit.")
-            .def("transistor_cost", &syrec::Circuit::transistorCost, "Returns the transistor cost of the circuit.");
+            .def("transistor_cost", &syrec::Circuit::transistorCost, "Returns the transistor cost of the circuit.")
+            .def("to_qasm_str", &syrec::Circuit::toQasm, "Returns the QASM representation of the circuit.")
+            .def("to_qasm_file", &syrec::Circuit::toQasmFile, "filename"_a, "Writes the QASM representation of the circuit to a file.");
 
     py::class_<Properties, std::shared_ptr<Properties>>(m, "properties")
             .def(py::init<>(), "Constructs property map object.")

--- a/test/python/test_syrec.py
+++ b/test/python/test_syrec.py
@@ -107,3 +107,13 @@ def test_simulation_add_lines(data_cost_aware_simulation):
 
         syrec.simple_simulation(my_out_bitset, circ, my_inp_bitset)
         assert data_cost_aware_simulation[file_name]["sim_out"] == str(my_out_bitset)
+
+
+def test_no_lines_to_qasm(data_line_aware_synthesis):
+    for file_name in data_line_aware_synthesis:
+        circ = syrec.circuit()
+        prog = syrec.program()
+        prog.read(str(circuit_dir / (file_name + ".src")))
+        if file_name != "negate_8":
+            b = circ.to_qasm_file(str(circuit_dir / (file_name + ".qasm")))
+            assert b is True

--- a/test/python/test_syrec.py
+++ b/test/python/test_syrec.py
@@ -114,6 +114,4 @@ def test_no_lines_to_qasm(data_line_aware_synthesis):
         circ = syrec.circuit()
         prog = syrec.program()
         prog.read(str(circuit_dir / (file_name + ".src")))
-        if file_name != "negate_8":
-            b = circ.to_qasm_file(str(circuit_dir / (file_name + ".qasm")))
-            assert b is True
+        assert circ.to_qasm_file(str(circuit_dir / (file_name + ".qasm")))

--- a/test/unittests/test_line_aware_synthesis.cpp
+++ b/test/unittests/test_line_aware_synthesis.cpp
@@ -88,3 +88,21 @@ TEST_P(SyrecSynthesisTest, GenericSynthesisTest) {
     EXPECT_EQ(expectedQc, qc);
     EXPECT_EQ(expectedTc, tc);
 }
+
+TEST_P(SyrecSynthesisTest, GenericSynthesisQASMTest) {
+    Circuit             circ;
+    program             prog;
+    ReadProgramSettings settings;
+    std::string         errorString;
+
+    errorString = prog.read(fileName, settings);
+    EXPECT_TRUE(LineAwareSynthesis::synthesize(circ, prog));
+
+    // negate_8.src creates gate which is not supported by QASM
+    if (fileName != testCircuitsDir + "negate_8.src") {
+        auto lastIndex      = fileName.find_last_of('.');
+        auto outputFileName = fileName.substr(0, lastIndex);
+        auto success        = circ.toQasmFile(outputFileName + ".qasm");
+        EXPECT_TRUE(success);
+    }
+}

--- a/test/unittests/test_line_aware_synthesis.cpp
+++ b/test/unittests/test_line_aware_synthesis.cpp
@@ -93,16 +93,12 @@ TEST_P(SyrecSynthesisTest, GenericSynthesisQASMTest) {
     Circuit             circ;
     program             prog;
     ReadProgramSettings settings;
-    std::string         errorString;
 
-    errorString = prog.read(fileName, settings);
+    const auto errorString = prog.read(fileName, settings);
+    EXPECT_TRUE(errorString.empty());
     EXPECT_TRUE(LineAwareSynthesis::synthesize(circ, prog));
 
-    // negate_8.src creates gate which is not supported by QASM
-    if (fileName != testCircuitsDir + "negate_8.src") {
-        auto lastIndex      = fileName.find_last_of('.');
-        auto outputFileName = fileName.substr(0, lastIndex);
-        auto success        = circ.toQasmFile(outputFileName + ".qasm");
-        EXPECT_TRUE(success);
-    }
+    const auto lastIndex      = fileName.find_last_of('.');
+    const auto outputFileName = fileName.substr(0, lastIndex);
+    EXPECT_TRUE(circ.toQasmFile(outputFileName + ".qasm"));
 }


### PR DESCRIPTION
## Description

This PR adds some small helper functions to get the QASM string or file to a circuit generated by SyRec. As QASM has limited multi-control gate support this export function only supports X, CX, CCX, CCCX, SWAP and c-SWAP gates. If the created circuit contains other gates, an exception is thrown.



## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
